### PR TITLE
set default value for "tend" in plots back to "now"

### DIFF
--- a/pages/docu/plot/widget_plot.period.html
+++ b/pages/docu/plot/widget_plot.period.html
@@ -16,8 +16,8 @@
 	<div class="twig">
 		<code class="prettyprint">
 			&#123;&#123; plot.period('p1', 'bath_plot_value', 'avg', '3h') &#125;&#125;<br /><br />
-			&#123;&#123; plot.period('p2', ['bath_plot1', 'bath_plot2', 'bath_plot3'], 'avg', '1h', '0h', 0, 100, '', '', ['#aa0', '#a00', '#00a'], ['area', 'column', 'line']) &#125;&#125;<br /><br />
-			&#123;&#123; plot.period('p3', 'bath_plot_value', 'avg', '20h', '0h', 0, 100, '', '', '', '', '', '1h' ) &#125;&#125;<br />
+			&#123;&#123; plot.period('p2', ['bath_plot1', 'bath_plot2', 'bath_plot3'], 'avg', '1h', 'now', 0, 100, '', '', ['#aa0', '#a00', '#00a'], ['area', 'column', 'line']) &#125;&#125;<br /><br />
+			&#123;&#123; plot.period('p3', 'bath_plot_value', 'avg', '20h', 'now', 0, 100, '', '', '', '', '', '1h' ) &#125;&#125;<br />
 		</code>
 	</div>
 	<div class="html">
@@ -40,7 +40,7 @@
 
 				<div data-role="collapsible" data-collapsed="false">
 					<h3>p2: a plot with 3 series</h3>
-					{{ plot.period('p2', ['bath_plot1', 'bath_plot2', 'bath_plot3'], 'avg', '1h', '0h', 0, 100, '', '', ['#aa0', '#a00', '#00a'], ['area', 'column', 'line']) }}
+					{{ plot.period('p2', ['bath_plot1', 'bath_plot2', 'bath_plot3'], 'avg', '1h', 'now', 0, 100, '', '', ['#aa0', '#a00', '#00a'], ['area', 'column', 'line']) }}
 				</div>
 
 			</div>
@@ -51,7 +51,7 @@
 
 				<div data-role="collapsible" data-collapsed="false">
 					<h3>p3: a zoomable plot</h3>
-					{{ plot.period('p3', 'bath_plot_value', 'avg', '20h', '0h', 0, 100, '', '', '', '', '', '1h' ) }}
+					{{ plot.period('p3', 'bath_plot_value', 'avg', '20h', 'now', 0, 100, '', '', '', '', '', '1h' ) }}
 				</div>
 
 			</div>

--- a/widgets/plot.html
+++ b/widgets/plot.html
@@ -31,7 +31,7 @@
 * @param series of item/s. More item/s in array form: [ item1 , item2 ]
 * @param the mode: 'avg', 'sum', 'min', 'max'
 * @param the minimum time (x-axis): '1h', '2h'... (duration-format)
-* @param the maximum time (x-axis): '', '1h', '2h'... (duration-format, default: 0h (=now))
+* @param the maximum time (x-axis): '', '1h', '2h'... (duration-format, default: now)
 * @param the minimum for each y-axis (optional) use [ min_y-axis1, min_y-axis2, ...]
 * @param the maximum for each y-axis (optional) use [ max_y-axis1, max_y-axis2, ...]
 * @param the number of points in the period (optional)
@@ -49,8 +49,8 @@
 */
 
 {% macro multiaxis( id, item, mode, tmin, tmax, ymin, ymax, count, label, color, exposure, axis, zoom, assign, opposite, ycolor) %}
-	{% set tmax = (tmax|lower=='now' or tmax==0)? '0h' : tmax %}
-	<div id="{{ uid(page, id) }}" data-widget="plot.multiaxis" data-item="{{ implode(item, [mode|default('avg'), tmin|default('1h'), tmax|default('0h'), count|default(100) ]) }}"
+	{% set tmax = (tmax|lower=='0h' or tmax==0)? 'now' : tmax %}
+	<div id="{{ uid(page, id) }}" data-widget="plot.multiaxis" data-item="{{ implode(item, [mode|default('avg'), tmin|default('1h'), tmax|default('now'), count|default(100) ]) }}"
 		{% if ymin is not empty %} data-ymin="{{ implode(ymin) }}" {% endif %} {% if ymax is not empty %} data-ymax="{{ implode(ymax) }}" {% endif %}
 		data-label="{{ implode(label) }}" data-color="{{ implode(color) }}" data-exposure="{{ implode(exposure) }}" data-axis="{{ implode(axis) }}" 
 		{% if zoom is not empty %} data-zoom="{{ zoom }}" {% endif %}
@@ -70,7 +70,7 @@
 * @param series of item/s. More item/s in array form: [ item1 , item2 ]
 * @param the mode: 'avg', 'sum', 'min', 'max'
 * @param the minimum time (x-axis): '1h', '2h'... (duration-format)
-* @param the maximum time (x-axis): '', '1h', '2h'... (duration-format, default: 0h (=now))
+* @param the maximum time (x-axis): '', '1h', '2h'... (duration-format, default: now)
 * @param the minimum y-axis (optional)
 * @param the maximum y-axis (optional)
 * @param the number of points in the period
@@ -85,8 +85,8 @@
 * @see misc/fundamentals#Duration-Format
 */
 {% macro period(id, item, mode, tmin, tmax, ymin, ymax, count, label, color, exposure, axis, zoom) %}
-	{% set tmax = (tmax|lower=='now' or tmax==0)? '0h' : tmax %}
-	<div id="{{ uid(page, id) }}" data-widget="plot.period" data-item="{{ implode(item, [mode|default('avg'), tmin|default('1h'), tmax|default('0h'), count|default('100')]) }}"
+	{% set tmax = (tmax|lower=='0h' or tmax==0)? 'now' : tmax %}
+	<div id="{{ uid(page, id) }}" data-widget="plot.period" data-item="{{ implode(item, [mode|default('avg'), tmin|default('1h'), tmax|default('now'), count|default('100')]) }}"
 		{% if ymin is not empty %} data-ymin="{{ ymin }}" {% endif %} {% if ymax is not empty %} data-ymax="{{ ymax }}" {% endif %}
 		data-label="{{ implode(label) }}" data-color="{{ implode(color) }}" data-exposure="{{ implode(exposure) }}" data-axis="{{ implode(axis) }}"
 		{% if zoom is not empty %} data-zoom="{{ zoom }}" {% endif %}
@@ -107,7 +107,7 @@
 */
 {% macro rtr(id, item_actual, item_set, item_state, count) %}
 
-	<div id="{{ uid(page, id) }}" data-widget="plot.rtr" data-item="{{ implode([item_actual, item_set, item_state], ['avg', '1d', '0h', count|default(100)]) }}"
+	<div id="{{ uid(page, id) }}" data-widget="plot.rtr" data-item="{{ implode([item_actual, item_set, item_state], ['avg', '1d', 'now', count|default(100)]) }}"
 		data-step="50" data-label="{{ lang('plot.rtr', 'label') }}" data-axis="{{ lang('plot.rtr', 'axis') }}"
 		class="plot"></div>
 
@@ -142,7 +142,7 @@
 * @param unique id for this widget
 * @param the item. Only one item supported.
 * @param the minimum time (x-axis): '1h', '2h'... (duration-format)
-* @param the maximum time (x-axis): '', '1h', '2h'... (duration-format, default: 0h (=now))
+* @param the maximum time (x-axis): '', '1h', '2h'... (duration-format, default: now)
 * @param the minimum y-axis (optional)
 * @param the maximum y-axis (optional)
 * @param a unit, tries to get the format for that unit from the language-file (optional)
@@ -152,7 +152,7 @@
 * @see misc/fundamentals#Duration-Format
 */
 {% macro minmaxavg(id, gad, tmin, tmax, ymin, ymax, unit, axis, count) %}
-	{% set tmax = (tmax|lower=='now' or tmax==0)? '0h' : tmax %}
+	{% set tmax = (tmax|lower=='0h' or tmax==0)? 'now' : tmax %}
 	{% if once('highcharts-more') %}
 		<script src="vendor/plot.highcharts/highcharts-more.js"></script>
 	{% endif %}


### PR DESCRIPTION
see  see SmartVisuTNG/smartvisu#17 for discussion.

"0h" causes issues with smarthome driver. Synonym "now" is handeled correct